### PR TITLE
Add GetAddressesByEnsNames SDK method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+- Added GetAddressesByEnsNames method for resolving ENS names to addresses
+
 ## [0.3.0] - 2026-02-02
 
 ### Added 

--- a/client_ens.go
+++ b/client_ens.go
@@ -34,3 +34,30 @@ func (c *Client) GetEnsNames(ctx context.Context, params GetEnsNamesRequest) (*e
 		EnsNames: result,
 	}, nil
 }
+
+type GetAddressesByEnsNamesRequest struct {
+	Names []string
+}
+
+func (c *Client) GetAddressesByEnsNames(ctx context.Context, params GetAddressesByEnsNamesRequest) (*ens.EnsNameList, error) {
+	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/ens-address", c.baseURL), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	q := req.URL.Query()
+	if len(params.Names) != 0 {
+		q.Add("names", strings.Join(params.Names, ","))
+	}
+	req.URL.RawQuery = q.Encode()
+
+	var result []ens.EnsName
+	_, err = c.sendRequest(ctx, req, &result)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ens.EnsNameList{
+		EnsNames: result,
+	}, nil
+}


### PR DESCRIPTION
## Summary
- Add `GetAddressesByEnsNames` method to the SDK client for resolving ENS names to addresses
- Calls `GET /ens-address?names=...` on core-web-api
- Returns `EnsNameList` with address/name pairs

## Test plan
- [ ] Verify `go build ./...` passes
- [ ] Verify SDK method works against a running core-web-api instance

🤖 Generated with [Claude Code](https://claude.com/claude-code)